### PR TITLE
Temporarily don't publish non-existing public dir

### DIFF
--- a/src/RootServiceProvider.php
+++ b/src/RootServiceProvider.php
@@ -85,7 +85,7 @@ class RootServiceProvider extends ServiceProvider
             ], 'root-config');
 
             $this->publishes([
-                __DIR__.'/../public' => public_path('vendor/root'),
+                // __DIR__.'/../public' => public_path('vendor/root'),
                 __DIR__.'/../resources/js' => $this->app->resourcePath('js/vendor/root'),
                 __DIR__.'/../resources/sass' => $this->app->resourcePath('sass/vendor/root'),
             ], 'root-assets');


### PR DESCRIPTION
`root:publish` command produces

> Can't locate path: <......../vendor/conedevelopment/root/src/../public>
