### PR TITLE
Show mix warnings

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -5,6 +5,9 @@ mix.webpackConfig({
         publicPath: '/vendor/root/',
         chunkFilename: '[name].js',
     },
+    stats: {
+        children: true
+    },
 });
 
 mix.setPublicPath('./public')


### PR DESCRIPTION
```
3 WARNINGS in child compilations (Use 'stats.children: true' resp. '--stats-children' for more details)
webpack compiled with 3 warnings
```
