### PR TITLE
Add generics to Widgets

### DIFF
--- a/src/Support/Collections/Widgets.php
+++ b/src/Support/Collections/Widgets.php
@@ -7,6 +7,9 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Collection;
 
+/**
+ * @extends \Illuminate\Support\Collection<int, \Cone\Root\Widgets\Widget>
+ */
 class Widgets extends Collection
 {
     /**


### PR DESCRIPTION
A keretrendszerben már van PHP generics.
https://github.com/laravel/framework/blob/v9.5.1/src/Illuminate/Collections/Collection.php#L14-L15

Ez a PR a TKey-t és a TValue-t állítja be.