### PR TITLE
request and resolution rework

### DIFF
--- a/src/Fields/BelongsTo.php
+++ b/src/Fields/BelongsTo.php
@@ -2,15 +2,15 @@
 
 namespace Cone\Root\Fields;
 
+use Cone\Root\Http\Requests\RootRequest;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Request;
 
 class BelongsTo extends Relation
 {
     /**
      * {@inheritdoc}
      */
-    public function hydrate(Request $request, Model $model, mixed $value): void
+    public function hydrate(RootRequest $request, Model $model, mixed $value): void
     {
         $related = $this->resolveQuery($request, $model)->find($value);
 

--- a/src/Fields/Date.php
+++ b/src/Fields/Date.php
@@ -2,8 +2,8 @@
 
 namespace Cone\Root\Fields;
 
+use Cone\Root\Http\Requests\RootRequest;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Date as BaseDate;
 
 class Date extends Field
@@ -81,10 +81,10 @@ class Date extends Field
     /**
      * {@inheritdoc}
      */
-    public function resolveFormat(Request $request, Model $model): mixed
+    public function resolveFormat(RootRequest $request, Model $model): mixed
     {
         if (is_null($this->formatResolver)) {
-            $this->formatResolver = function (Request $request, Model $model, mixed $value): ?string {
+            $this->formatResolver = function (RootRequest $request, Model $model, mixed $value): ?string {
                 return is_null($value) ? $value : BaseDate::parse($value)->tz($this->timezone)->format($this->format);
             };
         }
@@ -95,11 +95,11 @@ class Date extends Field
     /**
      * Get the input representation of the field.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return array
      */
-    public function toInput(Request $request, Model $model): array
+    public function toInput(RootRequest $request, Model $model): array
     {
         return array_merge(parent::toInput($request, $model), [
             'with_time' => $this->withTime,

--- a/src/Fields/Editor.php
+++ b/src/Fields/Editor.php
@@ -3,9 +3,9 @@
 namespace Cone\Root\Fields;
 
 use Closure;
+use Cone\Root\Http\Requests\RootRequest;
 use Cone\Root\Traits\RegistersRoutes;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\URL;
@@ -90,11 +90,11 @@ class Editor extends Field
     /**
      * Register the routes using the given router.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Routing\Router  $router
      * @return void
      */
-    public function registerRoutes(Request $request, Router $router): void
+    public function registerRoutes(RootRequest $request, Router $router): void
     {
         $this->defaultRegisterRotues($request, $router);
 
@@ -108,11 +108,11 @@ class Editor extends Field
     /**
      * Get the input representation of the field.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return array
      */
-    public function toInput(Request $request, Model $model): array
+    public function toInput(RootRequest $request, Model $model): array
     {
         return array_merge(parent::toInput($request, $model), [
             'config' => $this->config,

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -4,12 +4,12 @@ namespace Cone\Root\Fields;
 
 use Closure;
 use Cone\Root\Http\Requests\CreateRequest;
+use Cone\Root\Http\Requests\RootRequest;
 use Cone\Root\Http\Requests\UpdateRequest;
 use Cone\Root\Traits\Authorizable;
 use Cone\Root\Traits\ResolvesVisibility;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
@@ -320,10 +320,10 @@ abstract class Field implements Arrayable
     /**
      * Determine if the field is sortable.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return bool
      */
-    public function isSortable(Request $request): bool
+    public function isSortable(RootRequest $request): bool
     {
         if ($this->sortable instanceof Closure) {
             return call_user_func_array($this->sortable, [$request]);
@@ -348,10 +348,10 @@ abstract class Field implements Arrayable
     /**
      * Determine if the field is searchable.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return bool
      */
-    public function isSearchable(Request $request): bool
+    public function isSearchable(RootRequest $request): bool
     {
         if ($this->searchable instanceof Closure) {
             return call_user_func_array($this->searchable, [$request]);
@@ -376,11 +376,11 @@ abstract class Field implements Arrayable
     /**
      * Resolve the default value.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return mixed
      */
-    public function resolveDefault(Request $request, Model $model): mixed
+    public function resolveDefault(RootRequest $request, Model $model): mixed
     {
         $value = $this->getDefaultValue($request, $model);
 
@@ -394,11 +394,11 @@ abstract class Field implements Arrayable
     /**
      * Get the default value from the model.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return mixed
      */
-    public function getDefaultValue(Request $request, Model $model): mixed
+    public function getDefaultValue(RootRequest $request, Model $model): mixed
     {
         return $model->getAttribute($this->getKey());
     }
@@ -419,11 +419,11 @@ abstract class Field implements Arrayable
     /**
      * Format the value.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return mixed
      */
-    public function resolveFormat(Request $request, Model $model): mixed
+    public function resolveFormat(RootRequest $request, Model $model): mixed
     {
         $value = $this->resolveDefault($request, $model);
 
@@ -437,11 +437,11 @@ abstract class Field implements Arrayable
     /**
      * Persist the request value on the model.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return void
      */
-    public function persist(Request $request, Model $model): void
+    public function persist(RootRequest $request, Model $model): void
     {
         $model->saving(function (Model $model) use ($request): void {
             $this->hydrate(
@@ -453,11 +453,11 @@ abstract class Field implements Arrayable
     /**
      * Get the value for hydrating the model.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return mixed
      */
-    public function getValueForHydrate(Request $request, Model $model): mixed
+    public function getValueForHydrate(RootRequest $request, Model $model): mixed
     {
         return $request->input($this->getKey());
     }
@@ -465,12 +465,12 @@ abstract class Field implements Arrayable
     /**
      * Hydrate the model.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  mixed  $value
      * @return void
      */
-    public function hydrate(Request $request, Model $model, mixed $value): void
+    public function hydrate(RootRequest $request, Model $model, mixed $value): void
     {
         $model->setAttribute($this->getKey(), $value);
     }
@@ -514,11 +514,11 @@ abstract class Field implements Arrayable
     /**
      * Resolve the attributes.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return array
      */
-    public function resolveAttributes(Request $request, Model $model): array
+    public function resolveAttributes(RootRequest $request, Model $model): array
     {
         return array_map(static function (mixed $attribute) use ($request, $model): mixed {
             return $attribute instanceof Closure
@@ -540,11 +540,11 @@ abstract class Field implements Arrayable
     /**
      * Get the display representation of the field.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return array
      */
-    public function toDisplay(Request $request, Model $model): array
+    public function toDisplay(RootRequest $request, Model $model): array
     {
         return array_merge($this->resolveAttributes($request, $model), [
             'formatted_value' => $this->resolveFormat($request, $model),
@@ -557,11 +557,11 @@ abstract class Field implements Arrayable
     /**
      * Get the input representation of the field.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return array
      */
-    public function toInput(Request $request, Model $model): array
+    public function toInput(RootRequest $request, Model $model): array
     {
         return array_merge($this->resolveAttributes($request, $model), [
             'component' => $this->getComponent(),
@@ -573,11 +573,11 @@ abstract class Field implements Arrayable
     /**
      * Get the validation representation of the field.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return array
      */
-    public function toValidate(Request $request, Model $model): array
+    public function toValidate(RootRequest $request, Model $model): array
     {
         $key = match (get_class($request)) {
             CreateRequest::class => 'create',

--- a/src/Fields/HasMany.php
+++ b/src/Fields/HasMany.php
@@ -2,15 +2,15 @@
 
 namespace Cone\Root\Fields;
 
+use Cone\Root\Http\Requests\RootRequest;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Request;
 
 class HasMany extends Relation
 {
     /**
      * {@inheritdoc}
      */
-    public function isSortable(Request $request): bool
+    public function isSortable(RootRequest $request): bool
     {
         return false;
     }
@@ -18,7 +18,7 @@ class HasMany extends Relation
     /**
      * {@inheritdoc}
      */
-    public function persist(Request $request, Model $model): void
+    public function persist(RootRequest $request, Model $model): void
     {
         $model->saved(function (Model $model) use ($request): void {
             $relation = $this->getRelation($model);
@@ -36,7 +36,7 @@ class HasMany extends Relation
     /**
      * {@inheritdoc}
      */
-    public function hydrate(Request $request, Model $model, mixed $value): void
+    public function hydrate(RootRequest $request, Model $model, mixed $value): void
     {
         $relation = $this->getRelation($model);
 
@@ -48,7 +48,7 @@ class HasMany extends Relation
     /**
      * {@inheritdoc}
      */
-    public function toInput(Request $request, Model $model): array
+    public function toInput(RootRequest $request, Model $model): array
     {
         return array_merge(parent::toInput($request, $model), [
             'multiple' => true,

--- a/src/Fields/HasOne.php
+++ b/src/Fields/HasOne.php
@@ -2,15 +2,15 @@
 
 namespace Cone\Root\Fields;
 
+use Cone\Root\Http\Requests\RootRequest;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Request;
 
 class HasOne extends Relation
 {
     /**
      * {@inheritdoc}
      */
-    public function persist(Request $request, Model $model): void
+    public function persist(RootRequest $request, Model $model): void
     {
         $model->saved(function (Model $model) use ($request): void {
             $this->hydrate(
@@ -28,7 +28,7 @@ class HasOne extends Relation
     /**
      * {@inheritdoc}
      */
-    public function hydrate(Request $request, Model $model, mixed $value): void
+    public function hydrate(RootRequest $request, Model $model, mixed $value): void
     {
         $relation = $this->getRelation($model);
 

--- a/src/Fields/Json.php
+++ b/src/Fields/Json.php
@@ -2,11 +2,11 @@
 
 namespace Cone\Root\Fields;
 
+use Cone\Root\Http\Requests\RootRequest;
 use Cone\Root\Models\TemporaryJson;
 use Cone\Root\Traits\RegistersRoutes;
 use Cone\Root\Traits\ResolvesFields;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Collection;
 
@@ -45,13 +45,27 @@ class Json extends Field
     }
 
     /**
+     * Handle the resolving event on the field instance.
+     *
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
+     * @param  \Cone\Root\Fields\Field  $field
+     * @return void
+     */
+    protected function resolveField(RootRequest $request, Field $field): void
+    {
+        $field->mergeAuthorizationResolver(function (...$parameters): bool {
+            return $this->authorized(...$parameters);
+        });
+    }
+
+    /**
      * Register the field routes.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Routing\Router  $router
      * @return void
      */
-    public function registerRoutes(Request $request, Router $router): void
+    public function registerRoutes(RootRequest $request, Router $router): void
     {
         $this->defaultRegisterRotues($request, $router);
 
@@ -63,7 +77,7 @@ class Json extends Field
     /**
      * {@inheritdoc}
      */
-    public function toInput(Request $request, Model $model): array
+    public function toInput(RootRequest $request, Model $model): array
     {
         $data = parent::toInput($request, $model);
 
@@ -89,11 +103,11 @@ class Json extends Field
     /**
      * Get the validation representation of the field.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return array
      */
-    public function toValidate(Request $request, Model $model): array
+    public function toValidate(RootRequest $request, Model $model): array
     {
         $fieldRules = $this->resolveFields($request)
                             ->available($request, $model)

--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -5,9 +5,9 @@ namespace Cone\Root\Fields;
 use Closure;
 use Cone\Root\Http\Controllers\MediaController;
 use Cone\Root\Http\Requests\ResourceRequest;
+use Cone\Root\Http\Requests\RootRequest;
 use Cone\Root\Models\Medium;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 
 class Media extends MorphToMany
@@ -49,11 +49,11 @@ class Media extends MorphToMany
     /**
      * Store the file using the given path and request.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  string  $path
      * @return \Cone\Root\Models\Medium
      */
-    public function store(Request $request, string $path): Medium
+    public function store(RootRequest $request, string $path): Medium
     {
         $medium = (Medium::proxy())::makeFrom($path);
 
@@ -69,7 +69,7 @@ class Media extends MorphToMany
     /**
      * {@inheritdoc}
      */
-    public function resolveOptions(Request $request, Model $model): array
+    public function resolveOptions(RootRequest $request, Model $model): array
     {
         return [];
     }
@@ -77,7 +77,7 @@ class Media extends MorphToMany
     /**
      * {@inheritdoc}
      */
-    public function mapOption(Request $request, Model $model, Model $related): array
+    public function mapOption(RootRequest $request, Model $model, Model $related): array
     {
         return array_merge(
             parent::mapOption($request, $model, $related),
@@ -120,7 +120,7 @@ class Media extends MorphToMany
     /**
      * {@inheritdoc}
      */
-    public function toInput(Request $request, Model $model): array
+    public function toInput(RootRequest $request, Model $model): array
     {
         return array_merge(parent::toInput($request, $model), [
             'selection' => $this->getDefaultValue($request, $model)

--- a/src/Fields/Relation.php
+++ b/src/Fields/Relation.php
@@ -4,11 +4,11 @@ namespace Cone\Root\Fields;
 
 use Closure;
 use Cone\Root\Http\Controllers\RelationController;
+use Cone\Root\Http\Requests\RootRequest;
 use Cone\Root\Traits\RegistersRoutes;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation as EloquentRelation;
-use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\URL;
@@ -187,7 +187,7 @@ abstract class Relation extends Field
     public function display(Closure|string $callback): static
     {
         if (is_string($callback)) {
-            $callback = static function (Request $request, Model $model) use ($callback) {
+            $callback = static function (RootRequest $request, Model $model) use ($callback) {
                 return $model->getAttribute($callback);
             };
         }
@@ -200,11 +200,11 @@ abstract class Relation extends Field
     /**
      * Resolve the display format or the query result.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $related
      * @return mixed
      */
-    public function resolveDisplay(Request $request, Model $related): mixed
+    public function resolveDisplay(RootRequest $request, Model $related): mixed
     {
         if (is_null($this->displayResolver)) {
             $this->display($related->getKeyName());
@@ -231,10 +231,10 @@ abstract class Relation extends Field
     /**
      * {@inheritdoc}
      */
-    public function resolveDefault(Request $request, Model $model): mixed
+    public function resolveDefault(RootRequest $request, Model $model): mixed
     {
         if (is_null($this->defaultResolver)) {
-            $this->defaultResolver = static function (Request $request, Model $model, mixed $value): mixed {
+            $this->defaultResolver = static function (RootRequest $request, Model $model, mixed $value): mixed {
                 if ($value instanceof Model) {
                     return $value->getKey();
                 } elseif ($value instanceof Collection) {
@@ -251,7 +251,7 @@ abstract class Relation extends Field
     /**
      * {@inheritdoc}
      */
-    public function getDefaultValue(Request $request, Model $model): mixed
+    public function getDefaultValue(RootRequest $request, Model $model): mixed
     {
         return $model->getAttribute($this->relation);
     }
@@ -259,10 +259,10 @@ abstract class Relation extends Field
     /**
      * {@inheritdoc}
      */
-    public function resolveFormat(Request $request, Model $model): mixed
+    public function resolveFormat(RootRequest $request, Model $model): mixed
     {
         if (is_null($this->formatResolver)) {
-            $this->formatResolver = function (Request $request, Model $model): mixed {
+            $this->formatResolver = function (RootRequest $request, Model $model): mixed {
                 $default = $this->getDefaultValue($request, $model);
 
                 if ($default instanceof Model) {
@@ -296,11 +296,11 @@ abstract class Relation extends Field
     /**
      * Resolve the related model's eloquent query.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function resolveQuery(Request $request, Model $model): Builder
+    public function resolveQuery(RootRequest $request, Model $model): Builder
     {
         $query = $this->getRelation($model)->getRelated()->newQuery();
 
@@ -318,11 +318,11 @@ abstract class Relation extends Field
     /**
      * Resolve the options for the field.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return array
      */
-    public function resolveOptions(Request $request, Model $model): array
+    public function resolveOptions(RootRequest $request, Model $model): array
     {
         return $this->resolveQuery($request, $model)
                     ->get()
@@ -335,12 +335,12 @@ abstract class Relation extends Field
     /**
      * Map the given option.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  \Illuminate\Database\Eloquent\Model  $related
      * @return array
      */
-    public function mapOption(Request $request, Model $model, Model $related): array
+    public function mapOption(RootRequest $request, Model $model, Model $related): array
     {
         return [
             'value' => $related->getKey(),
@@ -364,7 +364,7 @@ abstract class Relation extends Field
     /**
      * {@inheritdoc}
      */
-    public function toInput(Request $request, Model $model): array
+    public function toInput(RootRequest $request, Model $model): array
     {
         return array_merge(parent::toInput($request, $model), [
             'nullable' => $this->nullable,

--- a/src/Fields/Select.php
+++ b/src/Fields/Select.php
@@ -3,8 +3,8 @@
 namespace Cone\Root\Fields;
 
 use Closure;
+use Cone\Root\Http\Requests\RootRequest;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Request;
 
 class Select extends Field
 {
@@ -64,11 +64,11 @@ class Select extends Field
     /**
      * Resolve the options for the field.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return array
      */
-    public function resolveOptions(Request $request, Model $model): array
+    public function resolveOptions(RootRequest $request, Model $model): array
     {
         if (is_null($this->optionsResolver)) {
             return [];
@@ -87,14 +87,14 @@ class Select extends Field
     /**
      * Format the value.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return mixed
      */
-    public function resolveFormat(Request $request, Model $model): mixed
+    public function resolveFormat(RootRequest $request, Model $model): mixed
     {
         if (is_null($this->formatResolver)) {
-            $this->formatResolver = function (Request $request, Model $model, mixed $value): mixed {
+            $this->formatResolver = function (RootRequest $request, Model $model, mixed $value): mixed {
                 $options = array_column(
                     $this->resolveOptions($request, $model), 'formatted_value', 'value'
                 );
@@ -109,7 +109,7 @@ class Select extends Field
     /**
      * {@inheritdoc}
      */
-    public function toInput(Request $request, Model $model): array
+    public function toInput(RootRequest $request, Model $model): array
     {
         return array_merge(parent::toInput($request, $model), [
             'nullable' => $this->nullable,

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -2,10 +2,10 @@
 
 namespace Cone\Root\Filters;
 
+use Cone\Root\Http\Requests\RootRequest;
 use Cone\Root\Traits\Authorizable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 
 abstract class Filter implements Arrayable
@@ -33,12 +33,12 @@ abstract class Filter implements Arrayable
     /**
      * Apply the filter on the query.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    abstract public function apply(Request $request, Builder $query, mixed $value): Builder;
+    abstract public function apply(RootRequest $request, Builder $query, mixed $value): Builder;
 
     /**
      * Get the key.
@@ -73,10 +73,10 @@ abstract class Filter implements Arrayable
     /**
      * The default value of the filter.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return mixed
      */
-    public function default(Request $request): mixed
+    public function default(RootRequest $request): mixed
     {
         return $request->query($this->getKey());
     }
@@ -84,10 +84,10 @@ abstract class Filter implements Arrayable
     /**
      * Determine if the filter is active.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return bool
      */
-    public function active(Request $request): bool
+    public function active(RootRequest $request): bool
     {
         return ! empty($request->query($this->getKey()));
     }
@@ -119,10 +119,10 @@ abstract class Filter implements Arrayable
     /**
      * Get the input representation of the filter.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function toInput(Request $request): array
+    public function toInput(RootRequest $request): array
     {
         return array_merge($this->toArray(), [
             'active' => $this->active($request),

--- a/src/Filters/Search.php
+++ b/src/Filters/Search.php
@@ -4,9 +4,9 @@ namespace Cone\Root\Filters;
 
 use Cone\Root\Fields\Field;
 use Cone\Root\Fields\Relation;
+use Cone\Root\Http\Requests\RootRequest;
 use Cone\Root\Support\Collections\Fields;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Http\Request;
 
 class Search extends Filter
 {
@@ -31,12 +31,12 @@ class Search extends Filter
     /**
      * Apply the filter on the query.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function apply(Request $request, Builder $query, mixed $value): Builder
+    public function apply(RootRequest $request, Builder $query, mixed $value): Builder
     {
         if (empty($value)) {
             return $query;

--- a/src/Filters/SelectFilter.php
+++ b/src/Filters/SelectFilter.php
@@ -2,7 +2,7 @@
 
 namespace Cone\Root\Filters;
 
-use Illuminate\Http\Request;
+use Cone\Root\Http\Requests\RootRequest;
 use Illuminate\Support\Arr;
 
 abstract class SelectFilter extends Filter
@@ -24,10 +24,10 @@ abstract class SelectFilter extends Filter
     /**
      * Get the filter options.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    abstract public function options(Request $request): array;
+    abstract public function options(RootRequest $request): array;
 
     /**
      * Set the multiple attribute.
@@ -45,7 +45,7 @@ abstract class SelectFilter extends Filter
     /**
      * {@inheritdoc}
      */
-    public function default(Request $request): mixed
+    public function default(RootRequest $request): mixed
     {
         $default = parent::default($request);
 
@@ -55,7 +55,7 @@ abstract class SelectFilter extends Filter
     /**
      * {@inheritdoc}
      */
-    public function toInput(Request $request): array
+    public function toInput(RootRequest $request): array
     {
         $options = $this->options($request);
 

--- a/src/Filters/Sort.php
+++ b/src/Filters/Sort.php
@@ -4,11 +4,11 @@ namespace Cone\Root\Filters;
 
 use Cone\Root\Fields\Field;
 use Cone\Root\Fields\Relation;
+use Cone\Root\Http\Requests\RootRequest;
 use Cone\Root\Support\Collections\Fields;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation as EloquentRelation;
-use Illuminate\Http\Request;
 
 class Sort extends Filter
 {
@@ -33,12 +33,12 @@ class Sort extends Filter
     /**
      * Apply the filter on the query.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function apply(Request $request, Builder $query, mixed $value): Builder
+    public function apply(RootRequest $request, Builder $query, mixed $value): Builder
     {
         $value = array_replace(['by' => 'id', 'order' => 'desc'], (array) $value);
 
@@ -72,10 +72,10 @@ class Sort extends Filter
     /**
      * The default value of the filter.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return mixed
      */
-    public function default(Request $request): mixed
+    public function default(RootRequest $request): mixed
     {
         return [
             'by' => $request->query('sort.by', Model::CREATED_AT),

--- a/src/Filters/TrashStatus.php
+++ b/src/Filters/TrashStatus.php
@@ -3,21 +3,21 @@
 namespace Cone\Root\Filters;
 
 use Cone\Root\Filters\SelectFilter;
+use Cone\Root\Http\Requests\RootRequest;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Http\Request;
 
 class TrashStatus extends SelectFilter
 {
     /**
      * Apply the filter on the query.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function apply(Request $request, Builder $query, mixed $value): Builder
+    public function apply(RootRequest $request, Builder $query, mixed $value): Builder
     {
         if (! in_array(SoftDeletes::class, class_uses_recursive($query->getModel()))) {
             return $query;
@@ -36,10 +36,10 @@ class TrashStatus extends SelectFilter
     /**
      * Get the filter options.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function options(Request $request): array
+    public function options(RootRequest $request): array
     {
         return [
             'available' => __('Available'),

--- a/src/RootServiceProvider.php
+++ b/src/RootServiceProvider.php
@@ -151,10 +151,12 @@ class RootServiceProvider extends ServiceProvider
         $this->app['view']->composer('root::app', static function (View $view): void {
             $app = $view->getFactory()->getContainer();
 
+            $request = RootRequest::createFrom($app['request']);
+
             $view->with('root', [
-                'resources' => Support\Facades\Resource::available($app['request'])->values(),
+                'resources' => Support\Facades\Resource::available($request)->values(),
                 'translations' => (object) $app['translator']->getLoader()->load($app->getLocale(), '*', '*'),
-                'user' => $app['request']->user()->toRoot(),
+                'user' => $request->user()->toRoot(),
                 'config' => [
                     'name' => $app['config']->get('app.name'),
                     'url' => $app['url']->route('root.dashboard'),

--- a/src/Traits/Authorizable.php
+++ b/src/Traits/Authorizable.php
@@ -3,7 +3,7 @@
 namespace Cone\Root\Traits;
 
 use Closure;
-use Illuminate\Http\Request;
+use Cone\Root\Http\Requests\RootRequest;
 
 trait Authorizable
 {
@@ -28,7 +28,7 @@ trait Authorizable
 
         $resolver = $this->authorizationResolver;
 
-        return $this->authorize(static function (Request $request, ...$parameters) use ($callback, $resolver): bool {
+        return $this->authorize(static function (RootRequest $request, ...$parameters) use ($callback, $resolver): bool {
             return call_user_func_array($callback, [$request, ...$parameters])
                 && call_user_func_array($resolver, [$request, ...$parameters]);
         });
@@ -50,11 +50,11 @@ trait Authorizable
     /**
      * Resolve the authorization.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  array  ...$parameters
      * @return bool
      */
-    public function authorized(Request $request, ...$parameters): bool
+    public function authorized(RootRequest $request, ...$parameters): bool
     {
         return is_null($this->authorizationResolver)
             || call_user_func_array($this->authorizationResolver, [$request, ...$parameters]);

--- a/src/Traits/RegistersRoutes.php
+++ b/src/Traits/RegistersRoutes.php
@@ -3,7 +3,7 @@
 namespace Cone\Root\Traits;
 
 use Cone\Root\Http\Middleware\AuthorizeResolved;
-use Illuminate\Http\Request;
+use Cone\Root\Http\Requests\RootRequest;
 use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\App;
@@ -59,11 +59,11 @@ trait RegistersRoutes
     /**
      * Register the routes using the given router.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Routing\Router  $router
      * @return void
      */
-    public function registerRoutes(Request $request, Router $router): void
+    public function registerRoutes(RootRequest $request, Router $router): void
     {
         $this->setUri(sprintf('%s/%s', $router->getLastGroupPrefix(), $this->getKey()));
 

--- a/src/Traits/ResolvesActions.php
+++ b/src/Traits/ResolvesActions.php
@@ -3,8 +3,9 @@
 namespace Cone\Root\Traits;
 
 use Closure;
+use Cone\Root\Actions\Action;
+use Cone\Root\Http\Requests\RootRequest;
 use Cone\Root\Support\Collections\Actions;
-use Illuminate\Http\Request;
 
 trait ResolvesActions
 {
@@ -25,10 +26,10 @@ trait ResolvesActions
     /**
      * Define the actions for the resource.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function actions(Request $request): array
+    public function actions(RootRequest $request): array
     {
         return [];
     }
@@ -42,7 +43,7 @@ trait ResolvesActions
     public function withActions(array|Closure $actions): static
     {
         if (is_array($actions)) {
-            $actions = static function (Request $request, Actions $collection) use ($actions): Actions {
+            $actions = static function (RootRequest $request, Actions $collection) use ($actions): Actions {
                 return $collection->merge($actions);
             };
         }
@@ -55,10 +56,10 @@ trait ResolvesActions
     /**
      * Resolve the actions.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return \Cone\Root\Support\Collections\Actions
      */
-    public function resolveActions(Request $request): Actions
+    public function resolveActions(RootRequest $request): Actions
     {
         if (is_null($this->resolvedActions)) {
             $actions = Actions::make($this->actions($request));
@@ -67,11 +68,23 @@ trait ResolvesActions
                 $actions = call_user_func_array($this->actionsResolver, [$request, $actions]);
             }
 
-            $this->resolvedActions = $actions->each->mergeAuthorizationResolver(function (...$parameters): bool {
-                return $this->authorized(...$parameters);
+            $this->resolvedActions = $actions->each(function (Action $action) use ($request): void {
+                $this->resolveAction($request, $action);
             });
         }
 
         return $this->resolvedActions;
+    }
+
+    /**
+     * Handle the resolving event on the action instance.
+     *
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
+     * @param  \Cone\Root\Actions\Action  $action
+     * @return void
+     */
+    protected function resolveAction(RootRequest $request, Action $action): void
+    {
+        //
     }
 }

--- a/src/Traits/ResolvesExtracts.php
+++ b/src/Traits/ResolvesExtracts.php
@@ -3,8 +3,9 @@
 namespace Cone\Root\Traits;
 
 use Closure;
+use Cone\Root\Extracts\Extract;
+use Cone\Root\Http\Requests\RootRequest;
 use Cone\Root\Support\Collections\Extracts;
-use Illuminate\Http\Request;
 
 trait ResolvesExtracts
 {
@@ -25,10 +26,10 @@ trait ResolvesExtracts
     /**
      * Define the extracts for the resource.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function extracts(Request $request): array
+    public function extracts(RootRequest $request): array
     {
         return [];
     }
@@ -42,7 +43,7 @@ trait ResolvesExtracts
     public function withExtracts(array|Closure $extracts): static
     {
         if (is_array($extracts)) {
-            $extracts = static function (Request $request, Extracts $collection) use ($extracts): Extracts {
+            $extracts = static function (RootRequest $request, Extracts $collection) use ($extracts): Extracts {
                 return $collection->merge($extracts);
             };
         }
@@ -55,10 +56,10 @@ trait ResolvesExtracts
     /**
      * Resolve the extracts.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return \Cone\Root\Support\Collections\Extracts
      */
-    public function resolveExtracts(Request $request): Extracts
+    public function resolveExtracts(RootRequest $request): Extracts
     {
         if (is_null($this->resolvedExtracts)) {
             $extracts = Extracts::make($this->extracts($request));
@@ -67,11 +68,23 @@ trait ResolvesExtracts
                 $extracts = call_user_func_array($this->extractsResolver, [$request, $extracts]);
             }
 
-            $this->resolvedExtracts = $extracts->each->mergeAuthorizationResolver(function (...$parameters): bool {
-                return $this->authorized(...$parameters);
+            $this->resolvedExtracts = $extracts->each(function (Extract $extract) use ($request): void {
+                $this->resolveExtract($request, $extract);
             });
         }
 
         return $this->resolvedExtracts;
+    }
+
+    /**
+     * Handle the resolving event on the extract instance.
+     *
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
+     * @param  \Cone\Root\Extracts\Extract  $extract
+     * @return void
+     */
+    protected function resolveExtract(RootRequest $request, Extract $extract): void
+    {
+        //
     }
 }

--- a/src/Traits/ResolvesVisibility.php
+++ b/src/Traits/ResolvesVisibility.php
@@ -5,9 +5,9 @@ namespace Cone\Root\Traits;
 use Closure;
 use Cone\Root\Http\Requests\CreateRequest;
 use Cone\Root\Http\Requests\IndexRequest;
+use Cone\Root\Http\Requests\RootRequest;
 use Cone\Root\Http\Requests\ShowRequest;
 use Cone\Root\Http\Requests\UpdateRequest;
-use Illuminate\Http\Request;
 
 trait ResolvesVisibility
 {
@@ -21,10 +21,10 @@ trait ResolvesVisibility
     /**
      * Determine if the object is visible for the given request.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return bool
      */
-    public function visible(Request $request): bool
+    public function visible(RootRequest $request): bool
     {
         foreach ($this->visibilityResolvers as $callback) {
             if (! call_user_func_array($callback, [$request])) {
@@ -43,7 +43,7 @@ trait ResolvesVisibility
      */
     public function hiddenOnIndex(?Closure $callback = null): static
     {
-        return $this->hiddenOn(static function (Request $request) use ($callback): bool {
+        return $this->hiddenOn(static function (RootRequest $request) use ($callback): bool {
             return $request instanceof IndexRequest
                 && (is_null($callback) || call_user_func_array($callback, [$request]));
         });
@@ -57,7 +57,7 @@ trait ResolvesVisibility
      */
     public function hiddenOnCreate(?Closure $callback = null): static
     {
-        return $this->hiddenOn(static function (Request $request) use ($callback): bool {
+        return $this->hiddenOn(static function (RootRequest $request) use ($callback): bool {
             return $request instanceof CreateRequest
                 && (is_null($callback) || call_user_func_array($callback, [$request]));
         });
@@ -71,7 +71,7 @@ trait ResolvesVisibility
      */
     public function hiddenOnShow(?Closure $callback = null): static
     {
-        return $this->hiddenOn(static function (Request $request) use ($callback): bool {
+        return $this->hiddenOn(static function (RootRequest $request) use ($callback): bool {
             return $request instanceof ShowRequest
                 && (is_null($callback) || call_user_func_array($callback, [$request]));
         });
@@ -85,7 +85,7 @@ trait ResolvesVisibility
      */
     public function hiddenOnUpdate(?Closure $callback = null): static
     {
-        return $this->hiddenOn(static function (Request $request) use ($callback): bool {
+        return $this->hiddenOn(static function (RootRequest $request) use ($callback): bool {
             return $request instanceof UpdateRequest
                 && (is_null($callback) || call_user_func_array($callback, [$request]));
         });
@@ -99,7 +99,7 @@ trait ResolvesVisibility
      */
     public function visibleOnIndex(?Closure $callback = null): static
     {
-        return $this->visibleOn(static function (Request $request) use ($callback): bool {
+        return $this->visibleOn(static function (RootRequest $request) use ($callback): bool {
             return $request instanceof IndexRequest
                 && (is_null($callback) || call_user_func_array($callback, [$request]));
         });
@@ -113,7 +113,7 @@ trait ResolvesVisibility
      */
     public function visibleOnCreate(?Closure $callback = null): static
     {
-        return $this->visibleOn(static function (Request $request) use ($callback): bool {
+        return $this->visibleOn(static function (RootRequest $request) use ($callback): bool {
             return $request instanceof CreateRequest
                 && (is_null($callback) || call_user_func_array($callback, [$request]));
         });
@@ -127,7 +127,7 @@ trait ResolvesVisibility
      */
     public function visibleOnShow(?Closure $callback = null): static
     {
-        return $this->visibleOn(static function (Request $request) use ($callback): bool {
+        return $this->visibleOn(static function (RootRequest $request) use ($callback): bool {
             return $request instanceof ShowRequest
                 && (is_null($callback) || call_user_func_array($callback, [$request]));
         });
@@ -141,7 +141,7 @@ trait ResolvesVisibility
      */
     public function visibleOnUpdate(?Closure $callback = null): static
     {
-        return $this->visibleOn(static function (Request $request) use ($callback): bool {
+        return $this->visibleOn(static function (RootRequest $request) use ($callback): bool {
             return $request instanceof UpdateRequest
                 && (is_null($callback) || call_user_func_array($callback, [$request]));
         });
@@ -155,7 +155,7 @@ trait ResolvesVisibility
      */
     public function hiddenOnDisplay(?Closure $callback = null): static
     {
-        return $this->hiddenOn(static function (Request $request) use ($callback): bool {
+        return $this->hiddenOn(static function (RootRequest $request) use ($callback): bool {
             return ($request instanceof IndexRequest || $request instanceof ShowRequest)
                 && (is_null($callback) || call_user_func_array($callback, [$request]));
         });
@@ -169,7 +169,7 @@ trait ResolvesVisibility
      */
     public function hiddenOnForm(?Closure $callback = null): static
     {
-        return $this->hiddenOn(static function (Request $request) use ($callback): bool {
+        return $this->hiddenOn(static function (RootRequest $request) use ($callback): bool {
             return ($request instanceof CreateRequest || $request instanceof UpdateRequest)
                 && (is_null($callback) || call_user_func_array($callback, [$request]));
         });
@@ -183,7 +183,7 @@ trait ResolvesVisibility
      */
     public function visibleOnDisplay(?Closure $callback = null): static
     {
-        return $this->visibleOn(static function (Request $request) use ($callback): bool {
+        return $this->visibleOn(static function (RootRequest $request) use ($callback): bool {
             return ($request instanceof IndexRequest || $request instanceof ShowRequest)
                 && (is_null($callback) || call_user_func_array($callback, [$request]));
         });
@@ -197,7 +197,7 @@ trait ResolvesVisibility
      */
     public function visibleOnForm(?Closure $callback = null): static
     {
-        return $this->visibleOn(static function (Request $request) use ($callback): bool {
+        return $this->visibleOn(static function (RootRequest $request) use ($callback): bool {
             return ($request instanceof CreateRequest || $request instanceof UpdateRequest)
                 && (is_null($callback) || call_user_func_array($callback, [$request]));
         });
@@ -224,7 +224,7 @@ trait ResolvesVisibility
      */
     public function hiddenOn(Closure $callback): static
     {
-        return $this->visibleOn(static function (Request $request) use ($callback): bool {
+        return $this->visibleOn(static function (RootRequest $request) use ($callback): bool {
             return ! call_user_func_array($callback, [$request]);
         });
     }

--- a/src/Traits/ResolvesWidgets.php
+++ b/src/Traits/ResolvesWidgets.php
@@ -3,8 +3,9 @@
 namespace Cone\Root\Traits;
 
 use Closure;
+use Cone\Root\Http\Requests\RootRequest;
 use Cone\Root\Support\Collections\Widgets;
-use Illuminate\Http\Request;
+use Cone\Root\Widgets\Widget;
 
 trait ResolvesWidgets
 {
@@ -25,10 +26,10 @@ trait ResolvesWidgets
     /**
      * Define the widgets for the resource.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function widgets(Request $request): array
+    public function widgets(RootRequest $request): array
     {
         return [];
     }
@@ -42,7 +43,7 @@ trait ResolvesWidgets
     public function withWidgets(array|Closure $widgets): static
     {
         if (is_array($widgets)) {
-            $widgets = static function (Request $request, Widgets $collection) use ($widgets): Widgets {
+            $widgets = static function (RootRequest $request, Widgets $collection) use ($widgets): Widgets {
                 return $collection->merge($widgets);
             };
         }
@@ -55,10 +56,10 @@ trait ResolvesWidgets
     /**
      * Resolve the widgets.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return \Cone\Root\Support\Collections\Widgets
      */
-    public function resolveWidgets(Request $request): Widgets
+    public function resolveWidgets(RootRequest $request): Widgets
     {
         if (is_null($this->resolvedWidgets)) {
             $widgets = Widgets::make($this->widgets($request));
@@ -67,11 +68,23 @@ trait ResolvesWidgets
                 $widgets = call_user_func_array($this->widgetsResolver, [$request, $widgets]);
             }
 
-            $this->resolvedWidgets = $widgets->each->mergeAuthorizationResolver(function (...$parameters): bool {
-                return $this->authorized(...$parameters);
+            $this->resolvedWidgets = $widgets->each(function (Widget $widget) use ($request): void {
+                $this->resolveWidget($request, $widget);
             });
         }
 
         return $this->resolvedWidgets;
+    }
+
+    /**
+     * Handle the resolving event on the widget instance.
+     *
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
+     * @param  \Cone\Root\Widgets\Widget  $widget
+     * @return void
+     */
+    protected function resolveWidget(RootRequest $request, Widget $widget): void
+    {
+        //
     }
 }

--- a/src/Widgets/Widget.php
+++ b/src/Widgets/Widget.php
@@ -4,12 +4,12 @@ namespace Cone\Root\Widgets;
 
 use Closure;
 use Cone\Root\Http\Controllers\WidgetController;
+use Cone\Root\Http\Requests\RootRequest;
 use Cone\Root\Traits\Authorizable;
 use Cone\Root\Traits\RegistersRoutes;
 use Cone\Root\Traits\ResolvesVisibility;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
-use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\URL;
@@ -117,10 +117,10 @@ abstract class Widget implements Arrayable, Renderable
     /**
      * Get the data.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function data(Request $request): array
+    public function data(RootRequest $request): array
     {
         return [];
     }

--- a/stubs/Action.stub
+++ b/stubs/Action.stub
@@ -4,8 +4,8 @@ namespace DummyNamespace;
 
 use Cone\Root\Actions\Action;
 use Cone\Root\Http\Requests\ActionRequest;
+use Cone\Root\Http\Requests\RootRequest;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Http\Request;
 
 class DummyClass extends Action
 {
@@ -33,11 +33,11 @@ class DummyClass extends Action
 
     /**
      * Define the fields for the action.
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      *
-     * @param  \Illuminate\Http\Request  $request
      * @return array
      */
-    public function fields(Request $request): array
+    public function fields(RootRequest $request): array
     {
         return array_merge(parent::fields($request), [
             //

--- a/stubs/Extract.stub
+++ b/stubs/Extract.stub
@@ -3,7 +3,7 @@
 namespace DummyNamespace;
 
 use Cone\Root\Extracts\Extract;
-use Illuminate\Http\Request;
+use Cone\Root\Http\Requests\RootRequest;
 use Illuminate\Database\Eloquent\Builder;
 
 class DummyClass extends Extract
@@ -11,10 +11,10 @@ class DummyClass extends Extract
     /**
      * Get the query for the extract.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function resolveQuery(Request $request): Builder
+    public function resolveQuery(RootRequest $request): Builder
     {
         return parent::resolveQuery($request);
     }
@@ -22,10 +22,10 @@ class DummyClass extends Extract
     /**
      * Define the fields for the extract.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function fields(Request $request): array
+    public function fields(RootRequest $request): array
     {
         return array_merge(parent::fields($request), [
             //
@@ -35,10 +35,10 @@ class DummyClass extends Extract
     /**
      * Define the filters for the extract.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function filters(Request $request): array
+    public function filters(RootRequest $request): array
     {
         return array_merge(parent::filters($request), [
             //
@@ -48,10 +48,10 @@ class DummyClass extends Extract
     /**
      * Define the actions for the extract.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function actions(Request $request): array
+    public function actions(RootRequest $request): array
     {
         return array_merge(parent::actions($request), [
             //
@@ -61,10 +61,10 @@ class DummyClass extends Extract
     /**
      * Define the widgets for the resource.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function widgets(Request $request): array
+    public function widgets(RootRequest $request): array
     {
         return array_merge(parent::widgets($request), [
             //

--- a/stubs/InputFilter.stub
+++ b/stubs/InputFilter.stub
@@ -3,8 +3,8 @@
 namespace DummyNamespace;
 
 use Cone\Root\Filters\InputFilter;
+use Cone\Root\Http\Requests\RootRequest;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Http\Request;
 
 class DummyClass extends InputFilter
 {
@@ -19,12 +19,12 @@ class DummyClass extends InputFilter
     /**
      * Apply the filter on the query.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function apply(Request $request, Builder $query, mixed $value): Builder
+    public function apply(RootRequest $request, Builder $query, mixed $value): Builder
     {
         return $query;
     }

--- a/stubs/Resource.stub
+++ b/stubs/Resource.stub
@@ -4,17 +4,17 @@ namespace DummyNamespace;
 
 use Cone\Root\Fields\ID;
 use Cone\Root\Resources\Resource;
-use Illuminate\Http\Request;
+use Cone\Root\Http\Requests\RootRequest;
 
 class DummyClass extends Resource
 {
     /**
      * Define the fields for the resource.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function fields(Request $request): array
+    public function fields(RootRequest $request): array
     {
         return array_merge(parent::fields($request), [
             ID::make()->sortable()->searchable(),
@@ -24,10 +24,10 @@ class DummyClass extends Resource
     /**
      * Define the filters for the resource.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function filters(Request $request): array
+    public function filters(RootRequest $request): array
     {
         return array_merge(parent::filters($request), [
             //
@@ -37,10 +37,10 @@ class DummyClass extends Resource
     /**
      * Define the actions for the resource.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function actions(Request $request): array
+    public function actions(RootRequest $request): array
     {
         return array_merge(parent::actions($request), [
             //
@@ -50,10 +50,10 @@ class DummyClass extends Resource
     /**
      * Define the extracts for the resource.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function extracts(Request $request): array
+    public function extracts(RootRequest $request): array
     {
         return array_merge(parent::extracts($request), [
             //
@@ -63,10 +63,10 @@ class DummyClass extends Resource
     /**
      * Define the widgets for the resource.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function widgets(Request $request): array
+    public function widgets(RootRequest $request): array
     {
         return array_merge(parent::widgets($request), [
             //

--- a/stubs/SelectFilter.stub
+++ b/stubs/SelectFilter.stub
@@ -4,7 +4,7 @@ namespace DummyNamespace;
 
 use Cone\Root\Filters\SelectFilter;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Http\Request;
+use Cone\Root\Http\Requests\RootRequest;
 
 class DummyClass extends SelectFilter
 {
@@ -27,12 +27,12 @@ class DummyClass extends SelectFilter
     /**
      * Apply the filter on the query.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function apply(Request $request, Builder $query, mixed $value): Builder
+    public function apply(RootRequest $request, Builder $query, mixed $value): Builder
     {
         return $query;
     }
@@ -40,10 +40,10 @@ class DummyClass extends SelectFilter
     /**
      * Get the filter options.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function options(Request $request): array
+    public function options(RootRequest $request): array
     {
         return [];
     }

--- a/stubs/UserResource.stub
+++ b/stubs/UserResource.stub
@@ -6,7 +6,7 @@ use Cone\Root\Fields\ID;
 use Cone\Root\Fields\Text;
 use Cone\Root\Resources\Resource;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Request;
+use Cone\Root\Http\Requests\RootRequest;
 use Illuminate\Validation\Rule;
 
 class UserResource extends Resource
@@ -14,7 +14,7 @@ class UserResource extends Resource
     /**
      * {@inheritdoc}
      */
-    public function fields(Request $request): array
+    public function fields(RootRequest $request): array
     {
         return array_merge(parent::fields($request), [
             ID::make(),

--- a/stubs/Widget.stub
+++ b/stubs/Widget.stub
@@ -3,7 +3,7 @@
 namespace DummyNamespace;
 
 use Cone\Root\Widgets\Widget;
-use Illuminate\Http\Request;
+use Cone\Root\Http\Requests\RootRequest;
 
 class DummyClass extends Widget
 {
@@ -43,10 +43,10 @@ class DummyClass extends Widget
     /**
      * Get the data.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Cone\Root\Http\Requests\RootRequest  $request
      * @return array
      */
-    public function data(Request $request): array
+    public function data(RootRequest $request): array
     {
         return array_merge(parent::data($request), [
             //

--- a/tests/Actions/ActionTest.php
+++ b/tests/Actions/ActionTest.php
@@ -25,7 +25,7 @@ class ActionTest extends TestCase
     public function an_action_registers_routes()
     {
         $this->app['router']->prefix('api/posts/actions')->group(function ($router) {
-            $this->action->registerRoutes($this->app['request'], $router);
+            $this->action->registerRoutes($this->request, $router);
         });
 
         $this->assertSame('api/posts/actions/publish-posts', $this->action->getUri());
@@ -39,7 +39,7 @@ class ActionTest extends TestCase
     /** @test */
     public function an_action_has_fields()
     {
-        $fields = $this->action->resolveFields($this->app['request']);
+        $fields = $this->action->resolveFields($this->request);
 
         $this->assertTrue($fields->contains(function ($field) {
             return $field->getKey() === 'title';
@@ -51,14 +51,14 @@ class ActionTest extends TestCase
     {
         $model = new Post();
 
-        $fields = $this->action->resolveFields($this->app['request'])->mapToForm($this->app['request'], $model)->toArray();
+        $fields = $this->action->resolveFields($this->request)->mapToForm($this->request, $model)->toArray();
 
         $this->assertSame(
             array_merge($this->action->toArray(), [
                 'data' => array_column($fields, 'value', 'name'),
                 'fields' => $fields,
             ]),
-            $this->action->toForm($this->app['request'], $model)
+            $this->action->toForm($this->request, $model)
         );
     }
 }

--- a/tests/Extracts/ExtractTest.php
+++ b/tests/Extracts/ExtractTest.php
@@ -25,7 +25,7 @@ class ExtractTest extends TestCase
     public function an_extract_registers_routes()
     {
         $this->app['router']->prefix('api/posts/extracts')->group(function ($router) {
-            $this->extract->registerRoutes($this->app['request'], $router);
+            $this->extract->registerRoutes($this->request, $router);
         });
 
         $this->assertSame('api/posts/extracts/long-posts', $this->extract->getUri());
@@ -39,7 +39,7 @@ class ExtractTest extends TestCase
     /** @test */
     public function a_extract_has_fields()
     {
-        $fields = $this->extract->resolveFields($this->app['request']);
+        $fields = $this->extract->resolveFields($this->request);
 
         $this->assertTrue($fields->contains(function ($field) {
             return $field->getKey() === 'title';
@@ -49,7 +49,7 @@ class ExtractTest extends TestCase
     /** @test */
     public function a_extract_has_filters()
     {
-        $filters = $this->extract->resolveFilters($this->app['request']);
+        $filters = $this->extract->resolveFilters($this->request);
 
         $this->assertTrue($filters->contains(function ($field) {
             return $field->getKey() === 'type';
@@ -59,7 +59,7 @@ class ExtractTest extends TestCase
     /** @test */
     public function a_extract_has_actions()
     {
-        $actions = $this->extract->resolveActions($this->app['request']);
+        $actions = $this->extract->resolveActions($this->request);
 
         $this->assertTrue($actions->contains(function ($field) {
             return $field->getKey() === 'publish-posts';
@@ -69,7 +69,7 @@ class ExtractTest extends TestCase
     /** @test */
     public function a_extract_has_widgets()
     {
-        $widgets = $this->extract->resolveWidgets($this->app['request']);
+        $widgets = $this->extract->resolveWidgets($this->request);
 
         $this->assertTrue($widgets->contains(function ($widget) {
             return $widget->getKey() === 'posts-count';

--- a/tests/Fields/BelongsToTest.php
+++ b/tests/Fields/BelongsToTest.php
@@ -33,7 +33,7 @@ class BelongsToTest extends TestCase
             Author::query()->get()->map(function ($model) {
                 return ['value' => $model->getKey(), 'formatted_value' => $model->getKey()];
             })->toArray(),
-            $this->field->resolveOptions($this->app['request'], $post)
+            $this->field->resolveOptions($this->request, $post)
         );
     }
 
@@ -48,7 +48,7 @@ class BelongsToTest extends TestCase
             Author::query()->get()->map(function ($model) {
                 return ['value' => $model->getKey(), 'formatted_value' => $model->name];
             })->toArray(),
-            $this->field->resolveOptions($this->app['request'], $post)
+            $this->field->resolveOptions($this->request, $post)
         );
 
         $closure = function ($request, $model) {
@@ -59,9 +59,9 @@ class BelongsToTest extends TestCase
 
         $this->assertSame(
             Author::query()->get()->map(function ($model) use ($closure) {
-                return ['value' => $model->getKey(), 'formatted_value' => $closure($this->app['request'], $model)];
+                return ['value' => $model->getKey(), 'formatted_value' => $closure($this->request, $model)];
             })->toArray(),
-            $this->field->resolveOptions($this->app['request'], $post)
+            $this->field->resolveOptions($this->request, $post)
         );
     }
 
@@ -72,14 +72,14 @@ class BelongsToTest extends TestCase
 
         $this->assertSame(
             'select * from "authors"',
-            $this->field->resolveQuery($this->app['request'], $post)->getQuery()->toSql()
+            $this->field->resolveQuery($this->request, $post)->getQuery()->toSql()
         );
 
         $this->field->withQuery(function ($request, $query) {
             return $query->where('authors.name', 'Foo');
         });
 
-        $query = $this->field->resolveQuery($this->app['request'], $post)->getQuery();
+        $query = $this->field->resolveQuery($this->request, $post)->getQuery();
 
         $this->assertSame('select * from "authors" where "authors"."name" = ?', $query->toSql());
         $this->assertSame(['Foo'], $query->getBindings());

--- a/tests/Fields/FieldTest.php
+++ b/tests/Fields/FieldTest.php
@@ -162,7 +162,7 @@ class FieldTest extends TestCase
     {
         $this->assertSame(
             $this->model->name,
-            $this->field->resolveDefault($this->app['request'], $this->model)
+            $this->field->resolveDefault($this->request, $this->model)
         );
 
         $this->field->default(function ($request, $model, $value) {
@@ -171,7 +171,7 @@ class FieldTest extends TestCase
 
         $this->assertSame(
             '__fake__',
-            $this->field->resolveDefault($this->app['request'], $this->model)
+            $this->field->resolveDefault($this->request, $this->model)
         );
     }
 
@@ -180,7 +180,7 @@ class FieldTest extends TestCase
     {
         $this->assertSame(
             $this->model->name,
-            $this->field->resolveFormat($this->app['request'], $this->model)
+            $this->field->resolveFormat($this->request, $this->model)
         );
 
         $this->field->format(function ($request, $model, $value) {
@@ -189,7 +189,7 @@ class FieldTest extends TestCase
 
         $this->assertSame(
             strtoupper($this->model->name),
-            $this->field->resolveFormat($this->app['request'], $this->model)
+            $this->field->resolveFormat($this->request, $this->model)
         );
     }
 
@@ -199,7 +199,7 @@ class FieldTest extends TestCase
         $this->assertNotSame('Root User', $this->model->name);
 
         $this->field->hydrate(
-            $this->app['request'], $this->model, 'Root User'
+            $this->request, $this->model, 'Root User'
         );
 
         $this->model->save();
@@ -216,7 +216,7 @@ class FieldTest extends TestCase
 
         $this->assertSame(
             [$this->field->name => ['required']],
-            $this->field->toValidate($this->app['request'], $this->model)
+            $this->field->toValidate($this->request, $this->model)
         );
 
         $this->assertSame(
@@ -236,11 +236,11 @@ class FieldTest extends TestCase
         $this->assertSame(
             array_merge($this->field->getAttributes(), [
                 'formatted_value' => $this->model->name,
-                'searchable' => $this->field->isSearchable($this->app['request']),
-                'sortable' => $this->field->isSortable($this->app['request']),
+                'searchable' => $this->field->isSearchable($this->request),
+                'sortable' => $this->field->isSortable($this->request),
                 'value' => $this->model->name,
             ]),
-            $this->field->toDisplay($this->app['request'], $this->model)
+            $this->field->toDisplay($this->request, $this->model)
         );
     }
 
@@ -253,27 +253,27 @@ class FieldTest extends TestCase
                 'formatted_value' => $this->model->name,
                 'value' => $this->model->name,
             ]),
-            $this->field->toInput($this->app['request'], $this->model)
+            $this->field->toInput($this->request, $this->model)
         );
     }
 
     /** @test */
     public function a_field_can_be_searchable()
     {
-        $this->assertFalse($this->field->isSearchable($this->app['request']));
+        $this->assertFalse($this->field->isSearchable($this->request));
 
         $this->field->searchable();
 
-        $this->assertTrue($this->field->isSearchable($this->app['request']));
+        $this->assertTrue($this->field->isSearchable($this->request));
     }
 
     /** @test */
     public function a_field_can_be_sortable()
     {
-        $this->assertFalse($this->field->isSortable($this->app['request']));
+        $this->assertFalse($this->field->isSortable($this->request));
 
         $this->field->sortable();
 
-        $this->assertTrue($this->field->isSortable($this->app['request']));
+        $this->assertTrue($this->field->isSortable($this->request));
     }
 }

--- a/tests/Fields/HasManyTest.php
+++ b/tests/Fields/HasManyTest.php
@@ -33,7 +33,7 @@ class HasManyTest extends TestCase
             Post::query()->get()->map(function ($model) {
                 return ['value' => $model->getKey(), 'formatted_value' => $model->getKey()];
             })->toArray(),
-            $this->field->resolveOptions($this->app['request'], $author)
+            $this->field->resolveOptions($this->request, $author)
         );
     }
 
@@ -48,7 +48,7 @@ class HasManyTest extends TestCase
             Post::query()->get()->map(function ($model) {
                 return ['value' => $model->getKey(), 'formatted_value' => $model->title];
             })->toArray(),
-            $this->field->resolveOptions($this->app['request'], $author)
+            $this->field->resolveOptions($this->request, $author)
         );
 
         $closure = function ($request, $model) {
@@ -59,9 +59,9 @@ class HasManyTest extends TestCase
 
         $this->assertSame(
             Post::query()->get()->map(function ($model) use ($closure) {
-                return ['value' => $model->getKey(), 'formatted_value' => $closure($this->app['request'], $model)];
+                return ['value' => $model->getKey(), 'formatted_value' => $closure($this->request, $model)];
             })->toArray(),
-            $this->field->resolveOptions($this->app['request'], $author)
+            $this->field->resolveOptions($this->request, $author)
         );
     }
 
@@ -72,14 +72,14 @@ class HasManyTest extends TestCase
 
         $this->assertSame(
             'select * from "posts"',
-            $this->field->resolveQuery($this->app['request'], $author)->getQuery()->toSql()
+            $this->field->resolveQuery($this->request, $author)->getQuery()->toSql()
         );
 
         $this->field->withQuery(function ($request, $query) {
             return $query->where('posts.title', 'Foo');
         });
 
-        $query = $this->field->resolveQuery($this->app['request'], $author)->getQuery();
+        $query = $this->field->resolveQuery($this->request, $author)->getQuery();
 
         $this->assertSame('select * from "posts" where "posts"."title" = ?', $query->toSql());
         $this->assertSame(['Foo'], $query->getBindings());

--- a/tests/Fields/SelectTest.php
+++ b/tests/Fields/SelectTest.php
@@ -28,13 +28,13 @@ class SelectTest extends TestCase
     {
         $author = new Author();
 
-        $this->assertEmpty($this->field->resolveOptions($this->app['request'], $author));
+        $this->assertEmpty($this->field->resolveOptions($this->request, $author));
 
         $this->field->options(['key' => 'value']);
 
         $this->assertSame(
             [['value' => 'key', 'formatted_value' => 'value']],
-            $this->field->resolveOptions($this->app['request'], $author)
+            $this->field->resolveOptions($this->request, $author)
         );
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Cone\Root\Tests;
 
+use Cone\Root\Http\Requests\RootRequest;
 use Cone\Root\Models\User;
 use Cone\Root\Tests\CreatesApplication;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -13,13 +14,15 @@ abstract class TestCase extends BaseTestCase
     use CreatesApplication;
     use RefreshDatabase;
 
-    protected $admin;
+    protected $admin, $request;
 
     public function setUp(): void
     {
         parent::setUp();
 
         $this->withoutMix();
+
+        $this->request = RootRequest::createFrom($this->app['request']);
 
         Storage::fake('local');
         Storage::fake('public');


### PR DESCRIPTION
- Swap the `Illuminate\Http\Request` typehints to `Cone\Root\Http\Requests\Root\Request`, to make sure all Root related stuff runs in the proper contex.
- Rework the `Action`, `Field`, `Filter`, `Extract` and `Widget` resolution callbacks.