### PR TITLE
Add type to aid static analysis

### DIFF
--- a/src/Fields/BelongsToMany.php
+++ b/src/Fields/BelongsToMany.php
@@ -82,6 +82,7 @@ class BelongsToMany extends BelongsTo
      */
     public function getRelatedByPivot(Model $model, string $id): Model
     {
+        /** @var \Illuminate\Database\Eloquent\Relations\BelongsToMany $relation */
         $relation = $this->getRelation($model);
 
         $related = $relation->wherePivot($relation->newPivot()->getQualifiedKeyName(), $id)->firstOrFail();


### PR DESCRIPTION
`wherePivot()` is called on this relation.
That is available only in `BelongsToMany`.
https://github.com/laravel/framework/blob/bea761c852d5e443a3024bda55e31a533f6be1b3/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php#L362