### PR TITLE
Fix key usage

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -477,7 +477,7 @@ abstract class Field implements Arrayable
      */
     public function getValueForHydrate(RootRequest $request, Model $model): mixed
     {
-        return $request->input([$this->getKey()]);
+        return $request->input($this->getKey());
     }
 
     /**


### PR DESCRIPTION
`data_get` explodes keys at dots?

From https://github.com/conedevelopment/root/commit/fb60dc9c1c0e53d6980439e1a8effb4e5a91ed96#diff-22bb4c9ddfb67b736e92de38ac9fffc06904031c853cae90b1f35e270e04021e
