### PR TITLE
Add generics for toArray's return type

### DIFF
--- a/src/Support/Breadcrumbs.php
+++ b/src/Support/Breadcrumbs.php
@@ -5,6 +5,10 @@ namespace Cone\Root\Support;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\URL;
 
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
 class Breadcrumbs implements Arrayable
 {
     /**


### PR DESCRIPTION
Currently used:
https://github.com/conedevelopment/root/blob/2b9688f396ba9985d5efe639ea3011b7f1949300/src/Support/Breadcrumbs.php#L49-L54

From https://github.com/laravel/framework/blob/1814e8066a6ba658ad42a662de9d3263b9637f9c/src/Illuminate/Contracts/Support/Arrayable.php#L5-L9
