### PR TITLE
Stop Vite from producing chunks

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,13 @@ import vue from '@vitejs/plugin-vue';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 
 export default defineConfig({
+    build: {
+        rollupOptions: {
+            output: {
+                manualChunks: () => 'app',
+            },
+        },
+    },
     server: {
         https: true,
         host: 'localhost',


### PR DESCRIPTION
- app.js:chunk ~ 400:1
- less files
- less HTTP requests
- quicker builds

From: https://github.com/rollup/rollup/issues/2756
