### PR TITLE
Stop exporting Vite config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,4 +12,5 @@
 /phpunit.xml.dist export-ignore
 /tests export-ignore
 /yarn.lock export-ignore
+/vite.config.js export-ignore
 /webpack.mix.js export-ignore


### PR DESCRIPTION
Just that.

`git archive` shows exported files.

```bash
git archive HEAD | tar --list | grep -Ev '^(config|database|public|resources|routes|src|stubs)/'
```
