### PR TITLE
Fix front-end steps in install-laravel CI

### DIFF
--- a/.github/workflows/install-laravel.yml
+++ b/.github/workflows/install-laravel.yml
@@ -67,7 +67,9 @@ jobs:
       - name: "Install front-end dependencies"
         run: |
           cd laravel/
-          npm install --production
+          # laravel-vite-plugin is a devDependency
+          #npm install --production
+          npm install
 
       - name: "Build front-end"
         run: |

--- a/.github/workflows/install-laravel.yml
+++ b/.github/workflows/install-laravel.yml
@@ -65,7 +65,11 @@ jobs:
           vendor/bin/phpstan analyze -c vendor/nunomaduro/larastan/extension.neon -l 5 $(find app/Root/ -type f -name FooBar.php)
 
       - name: "Install front-end dependencies"
-        run: "npm install --production"
+        run: |
+          cd laravel/
+          npm install --production
 
       - name: "Build front-end"
-        run: "npm run build"
+        run: |
+          cd laravel/
+          npm run build


### PR DESCRIPTION
Up to now `npm build` ran in Root not in the Laravel sample app.