### PR TITLE
Fix dark/light mode logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 <p>
-  <a href="https://root.conedevelopment.com/#gh-light-mode-only">
-    <br/>
-    <img src="./.github/root-logo-dark.svg" alt="Root" width="100">
-    <br/>
-  </a>
-  <a href="https://root.conedevelopment.com/#gh-dark-mode-only">
-    <br/>
-    <img src="./.github/root-logo-light.svg" alt="Root" width="100">
-    <br/>
+  <a href="https://root.conedevelopment.com/">
+    <br>
+    <picture>
+      <source media="(prefers-color-scheme: light)" srcset="./.github/root-logo-dark.svg">
+      <source media="(prefers-color-scheme: dark)" srcset="./.github/root-logo-light.svg">
+      <img alt="Root" width="100" src="./.github/root-logo-light.svg">
+    </picture>
+    <br>
   </a>
 </p>
 


### PR DESCRIPTION
Docs: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to

@adamlaki Please check other Cone repos.
