### PR TITLE
Fix method name in DashboardController

### DIFF
--- a/src/Http/Controllers/DashboardController.php
+++ b/src/Http/Controllers/DashboardController.php
@@ -14,7 +14,7 @@ class DashboardController extends Controller
      */
     public function __invoke(Request $request, Root $root): Response
     {
-        return ResponseFactory::View('root::dashboard', [
+        return ResponseFactory::view('root::dashboard', [
             'widgets' => $root->widgets->all(),
         ]);
     }


### PR DESCRIPTION
```
Call to static method Illuminate\Routing\ResponseFactory::view() with incorrect case: View
```

