### PR TITLE
Show exc!

### DIFF
--- a/tests/Http/MediaControllerTest.php
+++ b/tests/Http/MediaControllerTest.php
@@ -36,6 +36,7 @@ class MediaControllerTest extends TestCase
     public function test_a_media_controller_handles_index(): void
     {
         $this->actingAs($this->admin)
+            ->withoutExceptionHandling()
             ->get('/root/users/'.$this->admin->getKey().'/fields/media')
             ->assertOk()
             ->assertJson($this->field->paginateRelatable($this->app['request'], $this->admin)->toArray());

--- a/tests/Http/MediaControllerTest.php
+++ b/tests/Http/MediaControllerTest.php
@@ -36,7 +36,6 @@ class MediaControllerTest extends TestCase
     public function test_a_media_controller_handles_index(): void
     {
         $this->actingAs($this->admin)
-            ->withoutExceptionHandling()
             ->get('/root/users/'.$this->admin->getKey().'/fields/media')
             ->assertOk()
             ->assertJson($this->field->paginateRelatable($this->app['request'], $this->admin)->toArray());
@@ -65,6 +64,7 @@ class MediaControllerTest extends TestCase
         $medium = Medium::factory()->create();
 
         $this->actingAs($this->admin)
+            ->withoutExceptionHandling()
             ->delete('/root/users/'.$this->admin->getKey().'/fields/media', ['ids' => [$medium->getKey()]])
             ->assertOk()
             ->assertJson(['deleted' => 1]);


### PR DESCRIPTION
```
1) Cone\Root\Tests\Http\MediaControllerTest::test_a_media_controller_handles_destroy

TypeError: Cone\Root\Policies\MediumPolicy::delete():
 Argument #1 ($user) must be of type App\Models\User,
 Cone\Root\Tests\User given,
 called in vendor/laravel/framework/src/Illuminate/Auth/Access/Gate.php on line 811
```
